### PR TITLE
Bugfix/esp initial default ap

### DIFF
--- a/esp/src/SckESP.cpp
+++ b/esp/src/SckESP.cpp
@@ -16,6 +16,9 @@ DNSServer dnsServer;
 
 void SckESP::setup()
 {
+    // turn off softAP if still active by default
+    WiFi.softAPdisconnect(true);
+
     // LED outputs
     pinMode(pinLED, OUTPUT);
     digitalWrite(pinLED, LOW);

--- a/esp/uploadESP.py
+++ b/esp/uploadESP.py
@@ -12,8 +12,8 @@ def before_upload(source, target, env):
 	myPort = selectPort(serialPorts())
 	if myPort:
 		print("Asking for upload bridge...")
-		myPort.write("")
-		myPort.write("esp -flash\n")
+		myPort.write(b"")
+		myPort.write(b"esp -flash\n")
 		env.Replace(UPLOAD_PORT=portName)
 		time.sleep(1)
 
@@ -89,10 +89,10 @@ def selectPort(ports):
 		try:
 			s = serial.Serial(port)
 			for i in range(3):
-				s.write('\r\n\r\n')
+				s.write(b'\r\n\r\n')
 				time.sleep(0.2)
 				response = s.read(s.in_waiting)
-				if 'SCK' in response or 'Sdcard' in response:
+				if b'SCK' in response or b'Sdcard' in response:
 					print('Smartcitizen kit found on ' + port)
 					global portName
 					portName = port


### PR DESCRIPTION
This fixes issue #84 where a WiFi network pops up for a short time after powering up the ESP until the network parameters are loaded. By explicitly disabling the AP as soon as possible in the startup the default network won't show up.